### PR TITLE
fix: replace removed import assertion in openReleasePage

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "@types/react-dom": "^19.1.2",
     "@types/semver": "^7.5.8",
     "@typescript-eslint/eslint-plugin": "^6.4.0",
+    "@typescript-eslint/parser": "^6.20.0",
     "eslint": "^8.0.1",
     "eslint-config-standard-with-typescript": "^40.0.0",
     "eslint-plugin-import": "^2.25.2",
@@ -96,7 +97,7 @@
     "resize-observer-polyfill": "^1.5.1",
     "sass": "^1.69.5",
     "tsx": "^4.19.3",
-    "typescript": "^5.2.2",
+    "typescript": "^5.3.0",
     "url-join": "^5.0.0",
     "vite": "^4.2.0",
     "vitest": "^2.0.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,7 +64,7 @@ importers:
         version: 4.3.0
       pinia:
         specifier: ^2.1.7
-        version: 2.1.7(typescript@5.2.2)(vue@3.3.8(typescript@5.2.2))
+        version: 2.1.7(typescript@5.9.3)(vue@3.3.8(typescript@5.9.3))
       postcss:
         specifier: ^8.4.31
         version: 8.4.31
@@ -101,7 +101,7 @@ importers:
     devDependencies:
       '@commitlint/cli':
         specifier: ^18.4.3
-        version: 18.4.3(typescript@5.2.2)
+        version: 18.4.3(typescript@5.9.3)
       '@commitlint/config-conventional':
         specifier: ^18.4.3
         version: 18.4.3
@@ -113,7 +113,7 @@ importers:
         version: 8.3.0
       '@pinia/testing':
         specifier: ^0.1.3
-        version: 0.1.3(pinia@2.1.7(typescript@5.2.2)(vue@3.3.8(typescript@5.2.2)))(vue@3.3.8(typescript@5.2.2))
+        version: 0.1.3(pinia@2.1.7(typescript@5.9.3)(vue@3.3.8(typescript@5.9.3)))(vue@3.3.8(typescript@5.9.3))
       '@testing-library/dom':
         specifier: ^10.4.0
         version: 10.4.0
@@ -149,16 +149,19 @@ importers:
         version: 7.5.8
       '@typescript-eslint/eslint-plugin':
         specifier: ^6.4.0
-        version: 6.12.0(@typescript-eslint/parser@6.12.0(eslint@8.54.0)(typescript@5.2.2))(eslint@8.54.0)(typescript@5.2.2)
+        version: 6.12.0(@typescript-eslint/parser@6.21.0(eslint@8.54.0)(typescript@5.9.3))(eslint@8.54.0)(typescript@5.9.3)
+      '@typescript-eslint/parser':
+        specifier: ^6.20.0
+        version: 6.21.0(eslint@8.54.0)(typescript@5.9.3)
       eslint:
         specifier: ^8.0.1
         version: 8.54.0
       eslint-config-standard-with-typescript:
         specifier: ^40.0.0
-        version: 40.0.0(@typescript-eslint/eslint-plugin@6.12.0(@typescript-eslint/parser@6.12.0(eslint@8.54.0)(typescript@5.2.2))(eslint@8.54.0)(typescript@5.2.2))(eslint-plugin-import@2.29.0(@typescript-eslint/parser@6.12.0(eslint@8.54.0)(typescript@5.2.2))(eslint@8.54.0))(eslint-plugin-n@16.3.1(eslint@8.54.0))(eslint-plugin-promise@6.1.1(eslint@8.54.0))(eslint@8.54.0)(typescript@5.2.2)
+        version: 40.0.0(@typescript-eslint/eslint-plugin@6.12.0(@typescript-eslint/parser@6.21.0(eslint@8.54.0)(typescript@5.9.3))(eslint@8.54.0)(typescript@5.9.3))(eslint-plugin-import@2.29.0(@typescript-eslint/parser@6.21.0(eslint@8.54.0)(typescript@5.9.3))(eslint@8.54.0))(eslint-plugin-n@16.3.1(eslint@8.54.0))(eslint-plugin-promise@6.1.1(eslint@8.54.0))(eslint@8.54.0)(typescript@5.9.3)
       eslint-plugin-import:
         specifier: ^2.25.2
-        version: 2.29.0(@typescript-eslint/parser@6.12.0(eslint@8.54.0)(typescript@5.2.2))(eslint@8.54.0)
+        version: 2.29.0(@typescript-eslint/parser@6.21.0(eslint@8.54.0)(typescript@5.9.3))(eslint@8.54.0)
       eslint-plugin-n:
         specifier: '^15.0.0 || ^16.0.0 '
         version: 16.3.1(eslint@8.54.0)
@@ -176,7 +179,7 @@ importers:
         version: 0.4.20(eslint@8.54.0)
       eslint-plugin-testing-library:
         specifier: ^7.1.1
-        version: 7.1.1(eslint@8.54.0)(typescript@5.2.2)
+        version: 7.1.1(eslint@8.54.0)(typescript@5.9.3)
       fs-extra:
         specifier: ^11.3.0
         version: 11.3.0
@@ -197,7 +200,7 @@ importers:
         version: 9.1.0
       puppeteer:
         specifier: ^22.13.0
-        version: 22.13.0(typescript@5.2.2)
+        version: 22.13.0(typescript@5.9.3)
       resize-observer-polyfill:
         specifier: ^1.5.1
         version: 1.5.1
@@ -208,8 +211,8 @@ importers:
         specifier: ^4.19.3
         version: 4.19.3
       typescript:
-        specifier: ^5.2.2
-        version: 5.2.2
+        specifier: ^5.3.0
+        version: 5.9.3
       url-join:
         specifier: ^5.0.0
         version: 5.0.0
@@ -1364,8 +1367,8 @@ packages:
       typescript:
         optional: true
 
-  '@typescript-eslint/parser@6.12.0':
-    resolution: {integrity: sha512-s8/jNFPKPNRmXEnNXfuo1gemBdVmpQsK1pcu+QIvuNJuhFzGrpD7WjOcvDc/+uEdfzSYpNu7U/+MmbScjoQ6vg==}
+  '@typescript-eslint/parser@6.21.0':
+    resolution: {integrity: sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0
@@ -1376,6 +1379,10 @@ packages:
 
   '@typescript-eslint/scope-manager@6.12.0':
     resolution: {integrity: sha512-5gUvjg+XdSj8pcetdL9eXJzQNTl3RD7LgUiYTl8Aabdi8hFkaGSYnaS6BLc0BGNaDH+tVzVwmKtWvu0jLgWVbw==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+
+  '@typescript-eslint/scope-manager@6.21.0':
+    resolution: {integrity: sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==}
     engines: {node: ^16.0.0 || >=18.0.0}
 
   '@typescript-eslint/scope-manager@8.31.0':
@@ -1396,12 +1403,25 @@ packages:
     resolution: {integrity: sha512-MA16p/+WxM5JG/F3RTpRIcuOghWO30//VEOvzubM8zuOOBYXsP+IfjoCXXiIfy2Ta8FRh9+IO9QLlaFQUU+10Q==}
     engines: {node: ^16.0.0 || >=18.0.0}
 
+  '@typescript-eslint/types@6.21.0':
+    resolution: {integrity: sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+
   '@typescript-eslint/types@8.31.0':
     resolution: {integrity: sha512-Ch8oSjVyYyJxPQk8pMiP2FFGYatqXQfQIaMp+TpuuLlDachRWpUAeEu1u9B/v/8LToehUIWyiKcA/w5hUFRKuQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/typescript-estree@6.12.0':
     resolution: {integrity: sha512-vw9E2P9+3UUWzhgjyyVczLWxZ3GuQNT7QpnIY3o5OMeLO/c8oHljGc8ZpryBMIyympiAAaKgw9e5Hl9dCWFOYw==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@typescript-eslint/typescript-estree@6.21.0':
+    resolution: {integrity: sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
       typescript: '*'
@@ -1430,6 +1450,10 @@ packages:
 
   '@typescript-eslint/visitor-keys@6.12.0':
     resolution: {integrity: sha512-rg3BizTZHF1k3ipn8gfrzDXXSFKyOEB5zxYXInQ6z0hUvmQlhaZQzK+YmHmNViMA9HzW5Q9+bPPt90bU6GQwyw==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+
+  '@typescript-eslint/visitor-keys@6.21.0':
+    resolution: {integrity: sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==}
     engines: {node: ^16.0.0 || >=18.0.0}
 
   '@typescript-eslint/visitor-keys@8.31.0':
@@ -3264,6 +3288,10 @@ packages:
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
+  minimatch@9.0.3:
+    resolution: {integrity: sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
   minimatch@9.0.5:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -4246,8 +4274,8 @@ packages:
   typedarray-to-buffer@3.1.5:
     resolution: {integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==}
 
-  typescript@5.2.2:
-    resolution: {integrity: sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==}
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -4762,11 +4790,11 @@ snapshots:
       style-mod: 4.1.0
       w3c-keyname: 2.2.8
 
-  '@commitlint/cli@18.4.3(typescript@5.2.2)':
+  '@commitlint/cli@18.4.3(typescript@5.9.3)':
     dependencies:
       '@commitlint/format': 18.4.3
       '@commitlint/lint': 18.4.3
-      '@commitlint/load': 18.4.3(typescript@5.2.2)
+      '@commitlint/load': 18.4.3(typescript@5.9.3)
       '@commitlint/read': 18.4.3
       '@commitlint/types': 18.4.3
       execa: 5.1.1
@@ -4814,7 +4842,7 @@ snapshots:
       '@commitlint/rules': 18.4.3
       '@commitlint/types': 18.4.3
 
-  '@commitlint/load@18.4.3(typescript@5.2.2)':
+  '@commitlint/load@18.4.3(typescript@5.9.3)':
     dependencies:
       '@commitlint/config-validator': 18.4.3
       '@commitlint/execute-rule': 18.4.3
@@ -4822,8 +4850,8 @@ snapshots:
       '@commitlint/types': 18.4.3
       '@types/node': 18.19.3
       chalk: 4.1.2
-      cosmiconfig: 8.3.6(typescript@5.2.2)
-      cosmiconfig-typescript-loader: 5.0.0(@types/node@18.19.3)(cosmiconfig@8.3.6(typescript@5.2.2))(typescript@5.2.2)
+      cosmiconfig: 8.3.6(typescript@5.9.3)
+      cosmiconfig-typescript-loader: 5.0.0(@types/node@18.19.3)(cosmiconfig@8.3.6(typescript@5.9.3))(typescript@5.9.3)
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
@@ -5386,10 +5414,10 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.15.0
 
-  '@pinia/testing@0.1.3(pinia@2.1.7(typescript@5.2.2)(vue@3.3.8(typescript@5.2.2)))(vue@3.3.8(typescript@5.2.2))':
+  '@pinia/testing@0.1.3(pinia@2.1.7(typescript@5.9.3)(vue@3.3.8(typescript@5.9.3)))(vue@3.3.8(typescript@5.9.3))':
     dependencies:
-      pinia: 2.1.7(typescript@5.2.2)(vue@3.3.8(typescript@5.2.2))
-      vue-demi: 0.14.6(vue@3.3.8(typescript@5.2.2))
+      pinia: 2.1.7(typescript@5.9.3)(vue@3.3.8(typescript@5.9.3))
+      vue-demi: 0.14.6(vue@3.3.8(typescript@5.9.3))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
@@ -5577,13 +5605,13 @@ snapshots:
       '@types/node': 18.19.3
     optional: true
 
-  '@typescript-eslint/eslint-plugin@6.12.0(@typescript-eslint/parser@6.12.0(eslint@8.54.0)(typescript@5.2.2))(eslint@8.54.0)(typescript@5.2.2)':
+  '@typescript-eslint/eslint-plugin@6.12.0(@typescript-eslint/parser@6.21.0(eslint@8.54.0)(typescript@5.9.3))(eslint@8.54.0)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.10.0
-      '@typescript-eslint/parser': 6.12.0(eslint@8.54.0)(typescript@5.2.2)
+      '@typescript-eslint/parser': 6.21.0(eslint@8.54.0)(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 6.12.0
-      '@typescript-eslint/type-utils': 6.12.0(eslint@8.54.0)(typescript@5.2.2)
-      '@typescript-eslint/utils': 6.12.0(eslint@8.54.0)(typescript@5.2.2)
+      '@typescript-eslint/type-utils': 6.12.0(eslint@8.54.0)(typescript@5.9.3)
+      '@typescript-eslint/utils': 6.12.0(eslint@8.54.0)(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 6.12.0
       debug: 4.3.4
       eslint: 8.54.0
@@ -5591,22 +5619,22 @@ snapshots:
       ignore: 5.3.0
       natural-compare: 1.4.0
       semver: 7.6.2
-      ts-api-utils: 1.0.3(typescript@5.2.2)
+      ts-api-utils: 1.0.3(typescript@5.9.3)
     optionalDependencies:
-      typescript: 5.2.2
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@6.12.0(eslint@8.54.0)(typescript@5.2.2)':
+  '@typescript-eslint/parser@6.21.0(eslint@8.54.0)(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 6.12.0
-      '@typescript-eslint/types': 6.12.0
-      '@typescript-eslint/typescript-estree': 6.12.0(typescript@5.2.2)
-      '@typescript-eslint/visitor-keys': 6.12.0
-      debug: 4.3.4
+      '@typescript-eslint/scope-manager': 6.21.0
+      '@typescript-eslint/types': 6.21.0
+      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 6.21.0
+      debug: 4.3.7
       eslint: 8.54.0
     optionalDependencies:
-      typescript: 5.2.2
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
@@ -5615,42 +5643,64 @@ snapshots:
       '@typescript-eslint/types': 6.12.0
       '@typescript-eslint/visitor-keys': 6.12.0
 
+  '@typescript-eslint/scope-manager@6.21.0':
+    dependencies:
+      '@typescript-eslint/types': 6.21.0
+      '@typescript-eslint/visitor-keys': 6.21.0
+
   '@typescript-eslint/scope-manager@8.31.0':
     dependencies:
       '@typescript-eslint/types': 8.31.0
       '@typescript-eslint/visitor-keys': 8.31.0
 
-  '@typescript-eslint/type-utils@6.12.0(eslint@8.54.0)(typescript@5.2.2)':
+  '@typescript-eslint/type-utils@6.12.0(eslint@8.54.0)(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 6.12.0(typescript@5.2.2)
-      '@typescript-eslint/utils': 6.12.0(eslint@8.54.0)(typescript@5.2.2)
+      '@typescript-eslint/typescript-estree': 6.12.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 6.12.0(eslint@8.54.0)(typescript@5.9.3)
       debug: 4.3.4
       eslint: 8.54.0
-      ts-api-utils: 1.0.3(typescript@5.2.2)
+      ts-api-utils: 1.0.3(typescript@5.9.3)
     optionalDependencies:
-      typescript: 5.2.2
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
   '@typescript-eslint/types@6.12.0': {}
 
+  '@typescript-eslint/types@6.21.0': {}
+
   '@typescript-eslint/types@8.31.0': {}
 
-  '@typescript-eslint/typescript-estree@6.12.0(typescript@5.2.2)':
+  '@typescript-eslint/typescript-estree@6.12.0(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 6.12.0
       '@typescript-eslint/visitor-keys': 6.12.0
-      debug: 4.3.4
+      debug: 4.3.7
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.6.2
-      ts-api-utils: 1.0.3(typescript@5.2.2)
+      ts-api-utils: 1.0.3(typescript@5.9.3)
     optionalDependencies:
-      typescript: 5.2.2
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@8.31.0(typescript@5.2.2)':
+  '@typescript-eslint/typescript-estree@6.21.0(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/types': 6.21.0
+      '@typescript-eslint/visitor-keys': 6.21.0
+      debug: 4.3.7
+      globby: 11.1.0
+      is-glob: 4.0.3
+      minimatch: 9.0.3
+      semver: 7.6.3
+      ts-api-utils: 1.0.3(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/typescript-estree@8.31.0(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 8.31.0
       '@typescript-eslint/visitor-keys': 8.31.0
@@ -5659,39 +5709,44 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.5
       semver: 7.6.3
-      ts-api-utils: 2.1.0(typescript@5.2.2)
-      typescript: 5.2.2
+      ts-api-utils: 2.1.0(typescript@5.9.3)
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@6.12.0(eslint@8.54.0)(typescript@5.2.2)':
+  '@typescript-eslint/utils@6.12.0(eslint@8.54.0)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.54.0)
       '@types/json-schema': 7.0.15
       '@types/semver': 7.5.8
       '@typescript-eslint/scope-manager': 6.12.0
       '@typescript-eslint/types': 6.12.0
-      '@typescript-eslint/typescript-estree': 6.12.0(typescript@5.2.2)
+      '@typescript-eslint/typescript-estree': 6.12.0(typescript@5.9.3)
       eslint: 8.54.0
       semver: 7.6.2
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  '@typescript-eslint/utils@8.31.0(eslint@8.54.0)(typescript@5.2.2)':
+  '@typescript-eslint/utils@8.31.0(eslint@8.54.0)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.54.0)
       '@typescript-eslint/scope-manager': 8.31.0
       '@typescript-eslint/types': 8.31.0
-      '@typescript-eslint/typescript-estree': 8.31.0(typescript@5.2.2)
+      '@typescript-eslint/typescript-estree': 8.31.0(typescript@5.9.3)
       eslint: 8.54.0
-      typescript: 5.2.2
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
   '@typescript-eslint/visitor-keys@6.12.0':
     dependencies:
       '@typescript-eslint/types': 6.12.0
+      eslint-visitor-keys: 3.4.3
+
+  '@typescript-eslint/visitor-keys@6.21.0':
+    dependencies:
+      '@typescript-eslint/types': 6.21.0
       eslint-visitor-keys: 3.4.3
 
   '@typescript-eslint/visitor-keys@8.31.0':
@@ -5822,11 +5877,11 @@ snapshots:
       '@vue/shared': 3.3.8
       csstype: 3.1.2
 
-  '@vue/server-renderer@3.3.8(vue@3.3.8(typescript@5.2.2))':
+  '@vue/server-renderer@3.3.8(vue@3.3.8(typescript@5.9.3))':
     dependencies:
       '@vue/compiler-ssr': 3.3.8
       '@vue/shared': 3.3.8
-      vue: 3.3.8(typescript@5.2.2)
+      vue: 3.3.8(typescript@5.9.3)
 
   '@vue/shared@3.3.8': {}
 
@@ -5849,7 +5904,7 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.3.5
+      debug: 4.3.7
     transitivePeerDependencies:
       - supports-color
 
@@ -6318,30 +6373,30 @@ snapshots:
 
   core-util-is@1.0.3: {}
 
-  cosmiconfig-typescript-loader@5.0.0(@types/node@18.19.3)(cosmiconfig@8.3.6(typescript@5.2.2))(typescript@5.2.2):
+  cosmiconfig-typescript-loader@5.0.0(@types/node@18.19.3)(cosmiconfig@8.3.6(typescript@5.9.3))(typescript@5.9.3):
     dependencies:
       '@types/node': 18.19.3
-      cosmiconfig: 8.3.6(typescript@5.2.2)
+      cosmiconfig: 8.3.6(typescript@5.9.3)
       jiti: 1.21.0
-      typescript: 5.2.2
+      typescript: 5.9.3
 
-  cosmiconfig@8.3.6(typescript@5.2.2):
+  cosmiconfig@8.3.6(typescript@5.9.3):
     dependencies:
       import-fresh: 3.3.0
       js-yaml: 4.1.0
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
-      typescript: 5.2.2
+      typescript: 5.9.3
 
-  cosmiconfig@9.0.0(typescript@5.2.2):
+  cosmiconfig@9.0.0(typescript@5.9.3):
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.0
       js-yaml: 4.1.0
       parse-json: 5.2.0
     optionalDependencies:
-      typescript: 5.2.2
+      typescript: 5.9.3
 
   crelt@1.0.6: {}
 
@@ -6864,23 +6919,23 @@ snapshots:
     dependencies:
       eslint: 8.54.0
 
-  eslint-config-standard-with-typescript@40.0.0(@typescript-eslint/eslint-plugin@6.12.0(@typescript-eslint/parser@6.12.0(eslint@8.54.0)(typescript@5.2.2))(eslint@8.54.0)(typescript@5.2.2))(eslint-plugin-import@2.29.0(@typescript-eslint/parser@6.12.0(eslint@8.54.0)(typescript@5.2.2))(eslint@8.54.0))(eslint-plugin-n@16.3.1(eslint@8.54.0))(eslint-plugin-promise@6.1.1(eslint@8.54.0))(eslint@8.54.0)(typescript@5.2.2):
+  eslint-config-standard-with-typescript@40.0.0(@typescript-eslint/eslint-plugin@6.12.0(@typescript-eslint/parser@6.21.0(eslint@8.54.0)(typescript@5.9.3))(eslint@8.54.0)(typescript@5.9.3))(eslint-plugin-import@2.29.0(@typescript-eslint/parser@6.21.0(eslint@8.54.0)(typescript@5.9.3))(eslint@8.54.0))(eslint-plugin-n@16.3.1(eslint@8.54.0))(eslint-plugin-promise@6.1.1(eslint@8.54.0))(eslint@8.54.0)(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 6.12.0(@typescript-eslint/parser@6.12.0(eslint@8.54.0)(typescript@5.2.2))(eslint@8.54.0)(typescript@5.2.2)
-      '@typescript-eslint/parser': 6.12.0(eslint@8.54.0)(typescript@5.2.2)
+      '@typescript-eslint/eslint-plugin': 6.12.0(@typescript-eslint/parser@6.21.0(eslint@8.54.0)(typescript@5.9.3))(eslint@8.54.0)(typescript@5.9.3)
+      '@typescript-eslint/parser': 6.21.0(eslint@8.54.0)(typescript@5.9.3)
       eslint: 8.54.0
-      eslint-config-standard: 17.1.0(eslint-plugin-import@2.29.0(@typescript-eslint/parser@6.12.0(eslint@8.54.0)(typescript@5.2.2))(eslint@8.54.0))(eslint-plugin-n@16.3.1(eslint@8.54.0))(eslint-plugin-promise@6.1.1(eslint@8.54.0))(eslint@8.54.0)
-      eslint-plugin-import: 2.29.0(@typescript-eslint/parser@6.12.0(eslint@8.54.0)(typescript@5.2.2))(eslint@8.54.0)
+      eslint-config-standard: 17.1.0(eslint-plugin-import@2.29.0(@typescript-eslint/parser@6.21.0(eslint@8.54.0)(typescript@5.9.3))(eslint@8.54.0))(eslint-plugin-n@16.3.1(eslint@8.54.0))(eslint-plugin-promise@6.1.1(eslint@8.54.0))(eslint@8.54.0)
+      eslint-plugin-import: 2.29.0(@typescript-eslint/parser@6.21.0(eslint@8.54.0)(typescript@5.9.3))(eslint@8.54.0)
       eslint-plugin-n: 16.3.1(eslint@8.54.0)
       eslint-plugin-promise: 6.1.1(eslint@8.54.0)
-      typescript: 5.2.2
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  eslint-config-standard@17.1.0(eslint-plugin-import@2.29.0(@typescript-eslint/parser@6.12.0(eslint@8.54.0)(typescript@5.2.2))(eslint@8.54.0))(eslint-plugin-n@16.3.1(eslint@8.54.0))(eslint-plugin-promise@6.1.1(eslint@8.54.0))(eslint@8.54.0):
+  eslint-config-standard@17.1.0(eslint-plugin-import@2.29.0(@typescript-eslint/parser@6.21.0(eslint@8.54.0)(typescript@5.9.3))(eslint@8.54.0))(eslint-plugin-n@16.3.1(eslint@8.54.0))(eslint-plugin-promise@6.1.1(eslint@8.54.0))(eslint@8.54.0):
     dependencies:
       eslint: 8.54.0
-      eslint-plugin-import: 2.29.0(@typescript-eslint/parser@6.12.0(eslint@8.54.0)(typescript@5.2.2))(eslint@8.54.0)
+      eslint-plugin-import: 2.29.0(@typescript-eslint/parser@6.21.0(eslint@8.54.0)(typescript@5.9.3))(eslint@8.54.0)
       eslint-plugin-n: 16.3.1(eslint@8.54.0)
       eslint-plugin-promise: 6.1.1(eslint@8.54.0)
 
@@ -6892,11 +6947,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.8.0(@typescript-eslint/parser@6.12.0(eslint@8.54.0)(typescript@5.2.2))(eslint-import-resolver-node@0.3.9)(eslint@8.54.0):
+  eslint-module-utils@2.8.0(@typescript-eslint/parser@6.21.0(eslint@8.54.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@8.54.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 6.12.0(eslint@8.54.0)(typescript@5.2.2)
+      '@typescript-eslint/parser': 6.21.0(eslint@8.54.0)(typescript@5.9.3)
       eslint: 8.54.0
       eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
@@ -6909,7 +6964,7 @@ snapshots:
       eslint: 8.54.0
       eslint-compat-utils: 0.1.2(eslint@8.54.0)
 
-  eslint-plugin-import@2.29.0(@typescript-eslint/parser@6.12.0(eslint@8.54.0)(typescript@5.2.2))(eslint@8.54.0):
+  eslint-plugin-import@2.29.0(@typescript-eslint/parser@6.21.0(eslint@8.54.0)(typescript@5.9.3))(eslint@8.54.0):
     dependencies:
       array-includes: 3.1.7
       array.prototype.findlastindex: 1.2.3
@@ -6919,7 +6974,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.54.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.12.0(eslint@8.54.0)(typescript@5.2.2))(eslint-import-resolver-node@0.3.9)(eslint@8.54.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.21.0(eslint@8.54.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@8.54.0)
       hasown: 2.0.0
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -6930,7 +6985,7 @@ snapshots:
       semver: 6.3.1
       tsconfig-paths: 3.14.2
     optionalDependencies:
-      '@typescript-eslint/parser': 6.12.0(eslint@8.54.0)(typescript@5.2.2)
+      '@typescript-eslint/parser': 6.21.0(eslint@8.54.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -6990,10 +7045,10 @@ snapshots:
       postcss: 8.4.31
       tailwindcss: 3.3.5
 
-  eslint-plugin-testing-library@7.1.1(eslint@8.54.0)(typescript@5.2.2):
+  eslint-plugin-testing-library@7.1.1(eslint@8.54.0)(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/scope-manager': 8.31.0
-      '@typescript-eslint/utils': 8.31.0(eslint@8.54.0)(typescript@5.2.2)
+      '@typescript-eslint/utils': 8.31.0(eslint@8.54.0)(typescript@5.9.3)
       eslint: 8.54.0
     transitivePeerDependencies:
       - supports-color
@@ -7933,6 +7988,10 @@ snapshots:
     dependencies:
       brace-expansion: 1.1.11
 
+  minimatch@9.0.3:
+    dependencies:
+      brace-expansion: 2.0.1
+
   minimatch@9.0.5:
     dependencies:
       brace-expansion: 2.0.1
@@ -8193,13 +8252,13 @@ snapshots:
 
   pify@2.3.0: {}
 
-  pinia@2.1.7(typescript@5.2.2)(vue@3.3.8(typescript@5.2.2)):
+  pinia@2.1.7(typescript@5.9.3)(vue@3.3.8(typescript@5.9.3)):
     dependencies:
       '@vue/devtools-api': 6.5.1
-      vue: 3.3.8(typescript@5.2.2)
-      vue-demi: 0.14.6(vue@3.3.8(typescript@5.2.2))
+      vue: 3.3.8(typescript@5.9.3)
+      vue-demi: 0.14.6(vue@3.3.8(typescript@5.9.3))
     optionalDependencies:
-      typescript: 5.2.2
+      typescript: 5.9.3
 
   pirates@4.0.6: {}
 
@@ -8306,10 +8365,10 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  puppeteer@22.13.0(typescript@5.2.2):
+  puppeteer@22.13.0(typescript@5.9.3):
     dependencies:
       '@puppeteer/browsers': 2.2.3
-      cosmiconfig: 9.0.0(typescript@5.2.2)
+      cosmiconfig: 9.0.0(typescript@5.9.3)
       devtools-protocol: 0.0.1299070
       puppeteer-core: 22.13.0
     transitivePeerDependencies:
@@ -8922,13 +8981,13 @@ snapshots:
 
   trim-newlines@3.0.1: {}
 
-  ts-api-utils@1.0.3(typescript@5.2.2):
+  ts-api-utils@1.0.3(typescript@5.9.3):
     dependencies:
-      typescript: 5.2.2
+      typescript: 5.9.3
 
-  ts-api-utils@2.1.0(typescript@5.2.2):
+  ts-api-utils@2.1.0(typescript@5.9.3):
     dependencies:
-      typescript: 5.2.2
+      typescript: 5.9.3
 
   ts-interface-checker@0.1.13: {}
 
@@ -9028,7 +9087,7 @@ snapshots:
     dependencies:
       is-typedarray: 1.0.0
 
-  typescript@5.2.2: {}
+  typescript@5.9.3: {}
 
   uberproto@1.2.0: {}
 
@@ -9098,7 +9157,7 @@ snapshots:
   vite-node@2.0.1(@types/node@18.19.3)(sass@1.69.5):
     dependencies:
       cac: 6.7.14
-      debug: 4.3.5
+      debug: 4.3.7
       pathe: 1.1.2
       picocolors: 1.0.1
       vite: 5.3.3(@types/node@18.19.3)(sass@1.69.5)
@@ -9169,19 +9228,19 @@ snapshots:
 
   vscode-uri@3.0.8: {}
 
-  vue-demi@0.14.6(vue@3.3.8(typescript@5.2.2)):
+  vue-demi@0.14.6(vue@3.3.8(typescript@5.9.3)):
     dependencies:
-      vue: 3.3.8(typescript@5.2.2)
+      vue: 3.3.8(typescript@5.9.3)
 
-  vue@3.3.8(typescript@5.2.2):
+  vue@3.3.8(typescript@5.9.3):
     dependencies:
       '@vue/compiler-dom': 3.3.8
       '@vue/compiler-sfc': 3.3.8
       '@vue/runtime-dom': 3.3.8
-      '@vue/server-renderer': 3.3.8(vue@3.3.8(typescript@5.2.2))
+      '@vue/server-renderer': 3.3.8(vue@3.3.8(typescript@5.9.3))
       '@vue/shared': 3.3.8
     optionalDependencies:
-      typescript: 5.2.2
+      typescript: 5.9.3
 
   w3c-keyname@2.2.8: {}
 

--- a/scripts/openReleasePage.js
+++ b/scripts/openReleasePage.js
@@ -1,5 +1,5 @@
 import open from 'open'
-import packageJson from '../package.json' assert { type: 'json' }
+import packageJson from '../package.json' with { type: 'json' }
 
 export async function openReleasePage () {
   const { default: urlJoin } = await import('url-join')

--- a/src/modules/pattern.ts
+++ b/src/modules/pattern.ts
@@ -148,7 +148,7 @@ export function match (input: Nullish<string>, ruleOrRules: string | string[]) {
     stringPatterns ?? [],
   )
   const isMatchedRegexpPatterns = regexPatterns
-    .some((regex) => regex.test(input as string))
+    .some((regex) => regex.test(input))
 
   return isMatchedStringPatterns || isMatchedRegexpPatterns
 }


### PR DESCRIPTION
## Summary

- `node ./scripts/bump.js` was failing with `SyntaxError: Unexpected identifier 'assert'` on Node 22+, because the legacy `assert { type: 'json' }` import-assertion syntax was removed. Switched to the standard replacement `with { type: 'json' }` so the JSON module-type inference is preserved.
- The new `with` syntax also broke `npm run lint`. The transitive `@typescript-eslint/parser@6.12` and TypeScript `5.2.2` don't recognise import attributes, producing `Parsing error: ';' expected`. Added a direct `@typescript-eslint/parser ^6.20.0` devDep and bumped `typescript` to `^5.3.0` (resolves to 5.9 today).
- TS 5.9's stronger narrowing flagged one now-redundant `as string` cast in `src/modules/pattern.ts`; removed it to keep `@typescript-eslint/no-unnecessary-type-assertion` clean.

## Test plan

- [x] `node ./scripts/openReleasePage.js` — module imports without SyntaxError
- [x] `node ./scripts/bump.js` — imports load (script proceeds to `npx bumpp`)
- [x] `npm run lint` — passes
- [x] `npm run build` — passes